### PR TITLE
added custom fields to topic list item serializer

### DIFF
--- a/lib/qa_topic_edits.rb
+++ b/lib/qa_topic_edits.rb
@@ -225,6 +225,6 @@ class ::TopicListItemSerializer
   end
 
   def answer_count
-    qa_enabled ? object.answer_count : false ;
+    qa_enabled ? object.answer_count : false
   end
 end

--- a/lib/qa_topic_edits.rb
+++ b/lib/qa_topic_edits.rb
@@ -217,3 +217,14 @@ class ::TopicViewSerializer
     qa_enabled
   end
 end
+
+class ::TopicListItemSerializer
+  attributes :qa_enabled, :answer_count
+  def qa_enabled
+    Topic.qa_enabled object
+  end
+
+  def answer_count
+    qa_enabled ? object.answer_count : false ;
+  end
+end

--- a/lib/qa_topic_edits.rb
+++ b/lib/qa_topic_edits.rb
@@ -219,12 +219,22 @@ class ::TopicViewSerializer
 end
 
 class ::TopicListItemSerializer
-  attributes :qa_enabled, :answer_count
+  attributes :qa_enabled,
+             :answer_count
+
   def qa_enabled
+    true
+  end
+
+  def include_qa_enabled?
     Topic.qa_enabled object
   end
 
   def answer_count
-    qa_enabled ? object.answer_count : false
+    object.answer_count
+  end
+
+  def include_answer_count?
+    include_qa_enabled?
   end
 end


### PR DESCRIPTION
Added these fields to utilize them on `topic list items`. A fairly general use case for displaying answer count on `topic list item`s.