### PR TITLE
Added setting to enable/disable last_answerer attribute in the topic data.

### DIFF
--- a/assets/javascripts/discourse/initializers/qa-edits.js.es6
+++ b/assets/javascripts/discourse/initializers/qa-edits.js.es6
@@ -623,23 +623,24 @@ function initPlugin(api) {
       let lastAnswerUrl = attrs.topicUrl + "/" + attrs.last_answer_post_number;
       let postType = attrs.oneToMany ? "one_to_many" : "answer";
 
-      contents.push(
-        h(
-          "li",
-          h("a", { attributes: { href: lastAnswerUrl } }, [
-            h("h4", I18n.t(`last_${postType}_lowercase`)),
-            h("div.topic-map-post.last-answer", [
-              avatarFor("tiny", {
-                username: attrs.last_answerer.username,
-                template: attrs.last_answerer.avatar_template,
-                name: attrs.last_answerer.name
-              }),
-              dateNode(attrs.last_answered_at)
+      if(this.siteSettings.qa_show_last_answerer){
+        contents.push(
+          h(
+            "li",
+            h("a", { attributes: { href: lastAnswerUrl } }, [
+              h("h4", I18n.t(`last_${postType}_lowercase`)),
+              h("div.topic-map-post.last-answer", [
+                avatarFor("tiny", {
+                  username: attrs.last_answerer.username,
+                  template: attrs.last_answerer.avatar_template,
+                  name: attrs.last_answerer.name
+                }),
+                dateNode(attrs.last_answered_at)
+              ])
             ])
-          ])
-        )
-      );
-
+          )
+        );
+      }
       contents.push(
         h("li", [
           numberNode(attrs.answer_count),

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -13,6 +13,7 @@ en:
     qa_tl4_vote_limit: "The vote limit for the question and answer plugin for trust level 4 users"
     qa_tl_allow_multiple_votes_per_post: "Allow users to vote multiple times for the same post."
     qa_blacklist_tags: "Tags to disable QnA on topic"
+    qa_show_last_answerer: "Return last answerer data on topic request."
 
   post_action_types:
     vote:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -38,3 +38,6 @@ plugins:
   qa_blacklist_tags:
     type: list
     default: ""
+  qa_show_last_answerer:
+    default: false
+    client: true

--- a/extensions/post_serializer_extension.rb
+++ b/extensions/post_serializer_extension.rb
@@ -50,7 +50,7 @@ module QuestionAnswer
     end
 
     def include_last_answerer?
-      object.qa_enabled
+      this.siteSettings.qa_show_last_answerer
     end
 
     def last_answered_at

--- a/extensions/post_serializer_extension.rb
+++ b/extensions/post_serializer_extension.rb
@@ -50,7 +50,7 @@ module QuestionAnswer
     end
 
     def include_last_answerer?
-      this.siteSettings.qa_show_last_answerer
+      SiteSetting.qa_show_last_answerer
     end
 
     def last_answered_at
@@ -74,7 +74,7 @@ module QuestionAnswer
     end
 
     def include_last_answer_post_number?
-      object.qa_enabled
+      SiteSetting.qa_show_last_answerer
     end
   end
 end


### PR DESCRIPTION
Since some sensible data may be showing up on this attribute (password_hash and salt), added an option to enable, disable it. 

Current translations: en.
